### PR TITLE
Add matched imputation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,13 @@ setup(
     author_email="mghenis@gmail.com",
     license="MIT",
     packages=["synthimpute"],
-    install_requires=["numpy", "pandas", "scikit-learn", "statsmodels"],
+    install_requires=[
+        "numpy",
+        "pandas",
+        "scikit-learn",
+        "statsmodels",
+        "microdf",
+        "scipy",
+    ],
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
         "pandas",
         "scikit-learn",
         "statsmodels",
-        "microdf",
         "scipy",
     ],
     zip_safe=False,

--- a/synthimpute/rf_impute.py
+++ b/synthimpute/rf_impute.py
@@ -118,11 +118,7 @@ def rf_impute(
     # Set alpha parameter of Beta(a, 1) distribution.
     # Generate quantiles from Beta(a, 1) distribution.
     rng = np.random.default_rng(random_state)
-    if target is None:
-        a = mean_quantile / (1 - mean_quantile)
-        quantiles = rng.beta(a, 1, x_new.shape[0])
-        return rf_quantile(rf, x_new, quantiles)
-    else:
+    if target is not None:
 
         def aggregate_error(mean_quantile):
             a = mean_quantile / (1 - mean_quantile)
@@ -133,7 +129,22 @@ def rf_impute(
             return error
 
         mean_quantile = bisect(aggregate_error, 0.01, 0.99, rtol=rtol)
-        a = mean_quantile / (1 - mean_quantile)
-        quantiles = rng.beta(a, 1, x_new.shape[0])
-        pred = rf_quantile(rf, x_new, quantiles)
-        return pred
+    return get_result(rf, x_new, mean_quantile, rng)
+
+
+def get_result(rf, x_new, mean_quantile, rng):
+    """Generates the resulting array from a random forest regression model
+    using a specified mean quantile.
+
+    Args:
+        rf: The random forest model (fitted)
+        x_new: New input values
+        mean_quantile: The mean quantile using the Beta distribution
+        rng: The random number generator
+
+    Returns:
+        Imputed labels for x_new
+    """
+    a = mean_quantile / (1 - mean_quantile)
+    quantiles = rng.beta(a, 1, x_new.shape[0])
+    return rf_quantile(rf, x_new, quantiles)

--- a/synthimpute/rf_impute.py
+++ b/synthimpute/rf_impute.py
@@ -109,12 +109,12 @@ def rf_impute(
         rf = ensemble.RandomForestRegressor(
             random_state=random_state, **kwargs
         )
+        if sample_weight_train is None:
+            rf.fit(x_train, y_train)
+        else:
+            rf.fit(x_train, y_train, sample_weight=sample_weight_train)
     else:
         rf = rf_model
-    if sample_weight_train is None:
-        rf.fit(x_train, y_train)
-    else:
-        rf.fit(x_train, y_train, sample_weight=sample_weight_train)
     # Set alpha parameter of Beta(a, 1) distribution.
     # Generate quantiles from Beta(a, 1) distribution.
     rng = np.random.default_rng(random_state)
@@ -130,12 +130,10 @@ def rf_impute(
             pred = rf_quantile(rf, x_new, quantiles)
             pred_agg = (pred * new_weight).sum()
             error = pred_agg - target
-            print(a, pred_agg / 1e9, error / 1e9)
             return error
 
         mean_quantile = bisect(aggregate_error, 0.01, 0.99, rtol=rtol)
         a = mean_quantile / (1 - mean_quantile)
-        rng = np.random.default_rng(random_state)
         quantiles = rng.beta(a, 1, x_new.shape[0])
         pred = rf_quantile(rf, x_new, quantiles)
         return pred

--- a/synthimpute/rf_impute.py
+++ b/synthimpute/rf_impute.py
@@ -106,7 +106,9 @@ def rf_impute(
         y_train = y_train.values
         x_new = x_new.values
     if rf_model is None:
-        rf = ensemble.RandomForestRegressor(random_state=random_state, n_estimators=10, **kwargs)
+        rf = ensemble.RandomForestRegressor(
+            random_state=random_state, n_estimators=10, **kwargs
+        )
     else:
         rf = rf_model
     if sample_weight_train is None:
@@ -121,13 +123,14 @@ def rf_impute(
         quantiles = rng.beta(a, 1, x_new.shape[0])
         return rf_quantile(rf, x_new, quantiles)
     else:
+
         def aggregate_error(mean_quantile):
             a = mean_quantile / (1 - mean_quantile)
             quantiles = rng.beta(a, 1, x_new.shape[0])
             pred = rf_quantile(rf, x_new, quantiles)
             pred_agg = (pred * new_weight).sum()
             error = pred_agg - target
-            print(a, pred_agg / 1e+9, error / 1e+9)
+            print(a, pred_agg / 1e9, error / 1e9)
             return error
 
         mean_quantile = bisect(aggregate_error, 0.01, 0.99, rtol=rtol)

--- a/synthimpute/rf_impute.py
+++ b/synthimpute/rf_impute.py
@@ -107,7 +107,7 @@ def rf_impute(
         x_new = x_new.values
     if rf_model is None:
         rf = ensemble.RandomForestRegressor(
-            random_state=random_state, n_estimators=10, **kwargs
+            random_state=random_state, **kwargs
         )
     else:
         rf = rf_model

--- a/synthimpute/rf_impute.py
+++ b/synthimpute/rf_impute.py
@@ -54,7 +54,7 @@ def rf_impute(
     sample_weight_train=None,
     new_weight=None,
     target=None,
-    mean_quantile=None,
+    mean_quantile=0.5,
     rtol: float = 0.05,
     rf_model: ensemble.RandomForestRegressor = None,
     **kwargs
@@ -118,7 +118,7 @@ def rf_impute(
     # Set alpha parameter of Beta(a, 1) distribution.
     # Generate quantiles from Beta(a, 1) distribution.
     rng = np.random.default_rng(random_state)
-    if mean_quantile is not None:
+    if target is None:
         a = mean_quantile / (1 - mean_quantile)
         quantiles = rng.beta(a, 1, x_new.shape[0])
         return rf_quantile(rf, x_new, quantiles)


### PR DESCRIPTION
This adds a bisection routine to the random forest imputation to match an aggregate.

Added support for MicroSeries and MicroDataFrame inputs, but without needing microdf as a dependency.